### PR TITLE
Feature/send airtime

### DIFF
--- a/lib/at_ex.ex
+++ b/lib/at_ex.ex
@@ -7,4 +7,9 @@ defmodule AtEx do
   - Consuming incoming events that have been parsed
   - Building valid responses
   """
+  alias AtEx.{
+    Gateway.Airtime
+  }
+
+  defdelegate send_airtime(map), to: Airtime
 end

--- a/lib/at_ex/gateway/airtime.ex
+++ b/lib/at_ex/gateway/airtime.ex
@@ -27,15 +27,14 @@ defmodule AtEx.Gateway.Airtime do
       |> Map.put(:username, username)
       |> Map.put(:recipients, Jason.encode!(people))
 
-    with {:ok, %{status: 201} = res} <- post("/send", params),
-         {:ok, %{"responses" => _} = res} <- process_result(res.body) do
-      {:ok, res}
+    with {:ok, %{status: 201} = res} <- post("/send", params) do
+      {:ok, Jason.decode!(res.body)}
     else
-      {:ok, %{status: st, body: b}} ->
-        {:error, %{message: b, status: st}}
+      {:ok, val} ->
+        {:error, %{status: val.status, message: val.body}}
 
-      {:ok, data} ->
-        {:error, data}
+      {:error, message} ->
+        {:error, message}
     end
   end
 end

--- a/lib/at_ex/gateway/airtime.ex
+++ b/lib/at_ex/gateway/airtime.ex
@@ -1,0 +1,41 @@
+defmodule AtEx.Gateway.Airtime do
+  @moduledoc """
+  This module holds the implementation for the HTTP Gateway that runs calls against the Africas Talking API
+  Application Data endpoint, use it to POST and GET requests to the Application endpoint
+  """
+  use AtEx.Gateway.Base
+
+  @type send_input :: %{recipients: list(map())}
+  @type call_return :: {:ok, term()} | {:error, term()}
+
+  @doc """
+  Collects application data from Africas Talking endpoint, Use this function to collect
+  Data about your application
+
+  ## Parameters
+  * `none`
+
+  ## Examples
+      iex> AtEx.Airtime.send_airtime()
+  """
+  @spec send_airtime(send_input()) :: call_return()
+  def send_airtime(%{recipients: people} = attrs) do
+    username = Application.get_env(:at_ex, :username)
+
+    params =
+      attrs
+      |> Map.put(:username, username)
+      |> Map.put(:recipients, Jason.encode!(people))
+
+    with {:ok, %{status: 201} = res} <- post("/send", params),
+         {:ok, %{"responses" => _} = res} <- process_result(res.body) do
+      {:ok, res}
+    else
+      {:ok, %{status: st, body: b}} ->
+        {:error, %{message: b, status: st}}
+
+      {:ok, data} ->
+        {:error, data}
+    end
+  end
+end

--- a/lib/at_ex/gateway/airtime.ex
+++ b/lib/at_ex/gateway/airtime.ex
@@ -3,29 +3,34 @@ defmodule AtEx.Gateway.Airtime do
   This module holds the implementation for the HTTP Gateway that runs calls against the Africas Talking API
   Application Data endpoint, use it to POST and GET requests to the Application endpoint
   """
-  use AtEx.Gateway.Base
+  use AtEx.Gateway.Base, url: "https://api.sandbox.africastalking.com/version1/airtime"
 
   @type send_input :: %{recipients: list(map())}
   @type call_return :: {:ok, term()} | {:error, term()}
 
   @doc """
-  Collects application data from Africas Talking endpoint, Use this function to collect
-  Data about your application
+  Sends airtime to one or more numbers, accepts a map of parameters contaitning a list of maps each containing a
+  phone numbers and an amount of airtime to send out to a number this is expected in the `recipients` key.
 
   ## Parameters
-  * `none`
+  * `map`: map containg a recipiests which is a list of maps each with a phone number and amount
 
   ## Examples
-      iex> AtEx.Airtime.send_airtime()
+      
+      AtEx.Airtime.send_airtime(%{recipients: [%{phone_number: +254721978097, amount: "KES 50"}]})
   """
   @spec send_airtime(send_input()) :: call_return()
   def send_airtime(%{recipients: people} = attrs) do
     username = Application.get_env(:at_ex, :username)
 
+    serialized_people =
+      people
+      |> Enum.map(fn person -> serialize_person(person) end)
+
     params =
       attrs
       |> Map.put(:username, username)
-      |> Map.put(:recipients, Jason.encode!(people))
+      |> Map.put(:recipients, Jason.encode!(serialized_people))
 
     with {:ok, %{status: 201} = res} <- post("/send", params) do
       {:ok, Jason.decode!(res.body)}
@@ -37,4 +42,11 @@ defmodule AtEx.Gateway.Airtime do
         {:error, message}
     end
   end
+
+  @doc false
+  defp serialize_person(%{phone_number: pn, amount: amt}),
+    do: %{"phoneNumber" => pn, "amount" => amt}
+
+  defp serialize_person(item),
+    do: raise(ArgumentError, message: "recipient entry: #{inspect(item)} not valid")
 end

--- a/lib/at_ex/gateway/application.ex
+++ b/lib/at_ex/gateway/application.ex
@@ -11,16 +11,21 @@ defmodule AtEx.Gateway.Application do
 
   plug(Tesla.Middleware.BaseUrl, "https://api.sandbox.africastalking.com/version1")
   plug(Tesla.Middleware.FormUrlencoded)
-  plug(Tesla.Middleware.Headers, [{"accept", @accept}, {"content-type", @key}, {"apikey", @key}])
+
+  plug(Tesla.Middleware.Headers, [
+    {"accept", @accept},
+    {"content-type", @content_type},
+    {"apikey", @key}
+  ])
 
   @doc """
-  Collects application data from Africas Talking endpoint, Use this function to collect 
-  Data about your application 
+  Collects application data from Africas Talking endpoint, Use this function to collect
+  Data about your application
 
   ## Parameters
   * `none`
 
-  ## Examples 
+  ## Examples
       iex> AtEx.Gateway.Application.get_data()
   """
   @spec get_data :: {:ok, map()} | {:error, term()}

--- a/lib/at_ex/gateway/base_http.ex
+++ b/lib/at_ex/gateway/base_http.ex
@@ -4,17 +4,40 @@ defmodule AtEx.Gateway.Base do
   """
 
   @doc """
-  Macro to import necessary code into HTTP Gateways
+  Macro to import necessary code into HTTP Gateways, This Macro accepts a list as configuration at the moment it's used 
+  configure the  HTTP Base Url. 
+
+  ## Parameters 
+  * list: list of parameters for HTTP client configuration 
+
+  ## Examples 
+
+      defmodule AtEx.Gateway.Voice do 
+        use AtEx.Gateway.Base, url: "http://test.com"
+        @username "some_username"
+
+        def collect_minutes(attrs) do 
+          params =
+          attrs
+          |> Map.put(:username, @username)
+
+          {:ok, resp} = get("/minutes", params)
+          
+          process_result(resp.body)
+        end   
+      end 
   """
-  defmacro __using__(configs) do
+  defmacro __using__(opts) do
     quote do
       use Tesla
+
+      @config unquote(opts)
 
       @accept Application.get_env(:at_ex, :accept)
       @key Application.get_env(:at_ex, :api_key)
       @content_type Application.get_env(:at_ex, :content_type)
 
-      plug(Tesla.Middleware.BaseUrl, "https://api.sandbox.africastalking.com/version1/airtime")
+      plug(Tesla.Middleware.BaseUrl, @config[:url])
       plug(Tesla.Middleware.FormUrlencoded)
 
       plug(Tesla.Middleware.Headers, [

--- a/lib/at_ex/gateway/base_http.ex
+++ b/lib/at_ex/gateway/base_http.ex
@@ -1,0 +1,39 @@
+defmodule AtEx.Gateway.Base do
+  @moduledoc """
+  Base HTTP Gateway for `AtEx.Gateway.Base`
+  """
+
+  @doc """
+  Macro to import necessary code into HTTP Gateways
+  """
+  defmacro __using__(configs) do
+    quote do
+      use Tesla
+
+      @accept Application.get_env(:at_ex, :accept)
+      @key Application.get_env(:at_ex, :api_key)
+      @content_type Application.get_env(:at_ex, :content_type)
+
+      plug(Tesla.Middleware.BaseUrl, "https://api.sandbox.africastalking.com/version1/airtime")
+      plug(Tesla.Middleware.FormUrlencoded)
+
+      plug(Tesla.Middleware.Headers, [
+        {"accept", @accept},
+        {"content-type", @content_type},
+        {"apikey", @key}
+      ])
+
+      @doc """
+      Process results from calling the gateway
+      """
+      def process_result(result) do
+        with {:ok, res} <- Jason.decode(result) do
+          {:ok, res}
+        else
+          {:error, val} ->
+            {:error, val}
+        end
+      end
+    end
+  end
+end

--- a/test/at_ex/gateway/airtime_test.exs
+++ b/test/at_ex/gateway/airtime_test.exs
@@ -1,0 +1,69 @@
+defmodule AtEx.Gateway.AirtimeTest do
+  @moduledoc """
+  This module holds unit tests for the functions in the SMS gateway
+  """
+  use ExUnit.Case
+
+  alias AtEx.Gateway.Airtime
+
+  @attr "username="
+
+  setup do
+    Tesla.Mock.mock(fn
+      %{method: :post, body: @attr} ->
+        %Tesla.Env{
+          status: 400,
+          body: "Request is missing required form field 'to'"
+        }
+
+      %{method: :post} ->
+        %Tesla.Env{
+          status: 201,
+          body:
+            Jason.encode!(%{
+              "errorMessage" => "None",
+              "numSent" => 1,
+              "responses" => [
+                %{
+                  "amount" => "KES 10.0000",
+                  "discount" => "KES 0.4000",
+                  "errorMessage" => "None",
+                  "phoneNumber" => "+254728833158",
+                  "requestId" => "ATQid_977712e28f36c37d5ce3b376f5f0168b",
+                  "status" => "Sent"
+                }
+              ],
+              "totalAmount" => "ZAR 1.4055",
+              "totalDiscount" => "ZAR 0.0562"
+            })
+        }
+    end)
+
+    :ok
+  end
+
+  describe " Airtime Gateway" do
+    test "sends_airtime/1 should send airtime to recipient" do
+      # make message details
+      send_details = %{recipients: [%{"phoneNumber" => "+254728833158", "amount" => "KES 10"}]}
+
+      # run details through our code
+      {:ok, result} = Airtime.send_airtime(send_details)
+
+      # assert our code gives us a single element list of messages
+      [msg] = result["responses"]
+
+      # assert that message details correspond to details of set up message
+      assert msg["amount"] == "KES 10.0000"
+    end
+
+    # test "sends_airtime/1 should error out without phone number parameter" do
+    #   # run details through our code
+    #   {:error, result} = Airtime.send_airtime(%{})
+
+    #   "Request is missing required form field 'to'" = result.message
+
+    #   400 = result.status
+    # end
+  end
+end

--- a/test/at_ex/gateway/airtime_test.exs
+++ b/test/at_ex/gateway/airtime_test.exs
@@ -3,7 +3,7 @@ defmodule AtEx.Gateway.AirtimeTest do
   This module holds unit tests for the functions in the SMS gateway
   """
   use ExUnit.Case
-
+  doctest AtEx.Gateway.Airtime
   alias AtEx.Gateway.Airtime
 
   @attr "username="
@@ -45,7 +45,7 @@ defmodule AtEx.Gateway.AirtimeTest do
   describe " Airtime Gateway" do
     test "sends_airtime/1 should send airtime to recipient" do
       # make message details
-      send_details = %{recipients: [%{"phoneNumber" => "+254728833158", "amount" => "KES 10"}]}
+      send_details = %{recipients: [%{phone_number: "+254728833158", amount: "KES 10"}]}
 
       # run details through our code
       {:ok, result} = Airtime.send_airtime(send_details)
@@ -57,13 +57,13 @@ defmodule AtEx.Gateway.AirtimeTest do
       assert msg["amount"] == "KES 10.0000"
     end
 
-    # test "sends_airtime/1 should error out without phone number parameter" do
-    #   # run details through our code
-    #   {:error, result} = Airtime.send_airtime(%{})
+    test "sends_airtime/1 should raise if recipient entry is invalid" do
+      # make message details
+      send_details = %{recipients: [%{"phoneNumber" => "+254728833158", "amount" => "KES 10"}]}
 
-    #   "Request is missing required form field 'to'" = result.message
-
-    #   400 = result.status
-    # end
+      assert_raise ArgumentError, fn ->
+        Airtime.send_airtime(send_details)
+      end
+    end
   end
 end

--- a/test/at_ex/gateway/sms_test.exs
+++ b/test/at_ex/gateway/sms_test.exs
@@ -95,6 +95,5 @@ defmodule AtEx.Gateway.SmsTest do
       # assert that message details correspond to details of set up message
       assert msg["text"] == "Hello"
     end
-
   end
 end


### PR DESCRIPTION
Feature to send airtime and its associated tests. Decided not to use the `process_result` method that we introduced, as I tried it with other implementations and it was rendering wrong data. I propose we can refactor that later @zacck 