### PR TITLE
Generate Checkout Token

### DIFF
--- a/lib/at_ex/gateway/sms.ex
+++ b/lib/at_ex/gateway/sms.ex
@@ -62,6 +62,22 @@ defmodule AtEx.Gateway.Sms do
     end
   end
 
+  # Checkout token endpoints
+  @live_token_url "https://api.africastalking.com/checkout/token"
+  @sandbox_token_url "https://api.sandbox.africastalking.com/checkout/token"
+
+  # Using this system for delivery of which URL to use (sandbox or live) 
+  # determined by whether we ar in production or development or test
+  # Selection of the live URL can be forced by setting an environment
+  # variable FORCE_TOKEN_LIVE=YES
+  defp get_token_url do
+    cond do
+      Mix.env() == :prod -> @live_token_url
+      System.get_env("FORCE_TOKEN_LIVE") == "YES" -> @live_token_url
+      true -> @sandbox_token_url
+    end
+  end
+
   @doc """
   This function fetches the checkout token from the checkout token endpoint
   THIS IS DIFFERENT THAN THE SMS ENDPOINT!!
@@ -74,16 +90,11 @@ defmodule AtEx.Gateway.Sms do
   Returns a success tuple: {:ok, <client_token>}} or {:error, <reason>}
   """
 
-  # This should probably be a config value, since it only needs to be
-  # the sandbox in test and dev environments. It should be the live one
-  # in prod.
-  @token_url "https://api.sandbox.africastalking.com/checkout/token"
-
   @spec generate_checkout_token(String.t()) :: {:error, any()} | {:ok, any()}
   def generate_checkout_token(phone_number) do
     # Can't use the default client, since we have a different URL
     token_middleware = [
-      {Tesla.Middleware.BaseUrl, @token_url},
+      {Tesla.Middleware.BaseUrl, get_token_url()},
       Tesla.Middleware.FormUrlencoded
     ]
 

--- a/test/at_ex/gateway/sms_test.exs
+++ b/test/at_ex/gateway/sms_test.exs
@@ -8,22 +8,15 @@ defmodule AtEx.Gateway.SmsTest do
 
   @attr "username="
 
-  # Endpoint for getting the checkout token (should be migrated to config)
+  # Endpoint for getting the checkout token 
+  # Unless overridden, we will always use the sandbox URL during test
+  # If overridden, all the checkout token tests will fail.
   @checkout_token_url "https://api.sandbox.africastalking.com/checkout/token/create"
-  @success_checkout_phonenumber "+254728833181"
-  @success_checkout_query URI.encode_query(%{phoneNumber: @success_checkout_phonenumber})
+
+  # Values needed for checkout token tests
+  @checkout_token_phonenumber "+254728833181"
+  @checkout_token_query URI.encode_query(%{phoneNumber: @checkout_token_phonenumber})
   @checkout_token "CkTkn_SampleCkTknId123"
-  @checkout_status_failure_phonenumber "+17275551212"
-  @checkout_status_failure URI.encode_query(%{phoneNumber: @checkout_status_failure_phonenumber})
-  @checkout_description_failure_failure_phonenumber "+254728833182"
-  @checkout_description_failure_failure URI.encode_query(%{
-                                          phoneNumber:
-                                            @checkout_description_failure_failure_phonenumber
-                                        })
-  @checkout_token_none_failure_phonenumber "+254728833183"
-  @checkout_token_none_failure URI.encode_query(%{
-                                 phoneNumber: @checkout_token_none_failure_phonenumber
-                               })
 
   setup do
     Tesla.Mock.mock(fn
@@ -31,46 +24,6 @@ defmodule AtEx.Gateway.SmsTest do
         %Tesla.Env{
           status: 400,
           body: "Request is missing required form field 'to'"
-        }
-
-      # Mock for checkout token success
-      %{method: :post, url: @checkout_token_url, body: @success_checkout_query} ->
-        %Tesla.Env{
-          status: 201,
-          body:
-            Jason.encode!(%{
-              "description" => "Success",
-              "token" => @checkout_token
-            })
-        }
-
-      # Mock for checkout token failure due to status code.
-      %{method: :post, url: @checkout_token_url, body: @checkout_status_failure} ->
-        %Tesla.Env{
-          status: 500,
-          body: "Failure message"
-        }
-
-      # Mock for checkout token failure due to "token": "None"
-      %{method: :post, url: @checkout_token_url, body: @checkout_token_none_failure} ->
-        %Tesla.Env{
-          status: 201,
-          body:
-            Jason.encode!(%{
-              "description" => "Error Message",
-              "token" => "None"
-            })
-        }
-
-      # Mock for checkout token failure due to "description":  "Failure"
-      %{method: :post, url: @checkout_token_url, body: @checkout_description_failure_failure} ->
-        %Tesla.Env{
-          status: 201,
-          body:
-            Jason.encode!(%{
-              "description" => "Failure",
-              "token" => "Potential Error Message"
-            })
         }
 
       %{method: :post} ->
@@ -153,26 +106,72 @@ defmodule AtEx.Gateway.SmsTest do
       assert msg["text"] == "Hello"
     end
 
+    # Checkout token tests need their own mock calls, or we would need 
+    # separate phone numbers for each test.  This way values can be
+    # reused.
+
     test "fetch checkout token successfully" do
-      assert {:ok, token} = Sms.generate_checkout_token(@success_checkout_phonenumber)
+      Tesla.Mock.mock(fn
+        %{method: :post, url: @checkout_token_url, body: @checkout_token_query} ->
+          %Tesla.Env{
+            status: 201,
+            body:
+              Jason.encode!(%{
+                "description" => "Success",
+                "token" => @checkout_token
+              })
+          }
+      end)
+
+      assert {:ok, token} = Sms.generate_checkout_token(@checkout_token_phonenumber)
       assert token == @checkout_token
     end
 
     test "fetch checkout token failure token: none" do
-      assert {:error, message} =
-               Sms.generate_checkout_token(@checkout_token_none_failure_phonenumber)
+      Tesla.Mock.mock(fn
+        %{method: :post, url: @checkout_token_url, body: @checkout_token_query} ->
+          %Tesla.Env{
+            status: 201,
+            body:
+              Jason.encode!(%{
+                "description" => "Error Message",
+                "token" => "None"
+              })
+          }
+      end)
+
+      assert {:error, message} = Sms.generate_checkout_token(@checkout_token_phonenumber)
 
       assert message == "Failure - Error Message"
     end
 
     test "fetch checkout token failure status code" do
-      assert {:error, message} = Sms.generate_checkout_token(@checkout_status_failure_phonenumber)
+      Tesla.Mock.mock(fn
+        %{method: :post, url: @checkout_token_url, body: @checkout_token_query} ->
+          %Tesla.Env{
+            status: 500,
+            body: "Failure message"
+          }
+      end)
+
+      assert {:error, message} = Sms.generate_checkout_token(@checkout_token_phonenumber)
       assert message = "500 - Error Message"
     end
 
     test "fetch checkout token failure description: Failure" do
-      assert {:error, message} =
-               Sms.generate_checkout_token(@checkout_description_failure_failure_phonenumber)
+      Tesla.Mock.mock(fn
+        %{method: :post, url: @checkout_token_url, body: @checkout_token_query} ->
+          %Tesla.Env{
+            status: 201,
+            body:
+              Jason.encode!(%{
+                "description" => "Failure",
+                "token" => "Potential Error Message"
+              })
+          }
+      end)
+
+      assert {:error, message} = Sms.generate_checkout_token(@checkout_token_phonenumber)
 
       assert message == "Failure - Potential Error Message"
     end

--- a/test/at_ex/gateway/sms_test.exs
+++ b/test/at_ex/gateway/sms_test.exs
@@ -8,12 +8,69 @@ defmodule AtEx.Gateway.SmsTest do
 
   @attr "username="
 
+  # Endpoint for getting the checkout token (should be migrated to config)
+  @checkout_token_url "https://api.sandbox.africastalking.com/checkout/token/create"
+  @success_checkout_phonenumber "+254728833181"
+  @success_checkout_query URI.encode_query(%{phoneNumber: @success_checkout_phonenumber})
+  @checkout_token "CkTkn_SampleCkTknId123"
+  @checkout_status_failure_phonenumber "+17275551212"
+  @checkout_status_failure URI.encode_query(%{phoneNumber: @checkout_status_failure_phonenumber})
+  @checkout_description_failure_failure_phonenumber "+254728833182"
+  @checkout_description_failure_failure URI.encode_query(%{
+                                          phoneNumber:
+                                            @checkout_description_failure_failure_phonenumber
+                                        })
+  @checkout_token_none_failure_phonenumber "+254728833183"
+  @checkout_token_none_failure URI.encode_query(%{
+                                 phoneNumber: @checkout_token_none_failure_phonenumber
+                               })
+
   setup do
     Tesla.Mock.mock(fn
       %{method: :post, body: @attr} ->
         %Tesla.Env{
           status: 400,
           body: "Request is missing required form field 'to'"
+        }
+
+      # Mock for checkout token success
+      %{method: :post, url: @checkout_token_url, body: @success_checkout_query} ->
+        %Tesla.Env{
+          status: 201,
+          body:
+            Jason.encode!(%{
+              "description" => "Success",
+              "token" => @checkout_token
+            })
+        }
+
+      # Mock for checkout token failure due to status code.
+      %{method: :post, url: @checkout_token_url, body: @checkout_status_failure} ->
+        %Tesla.Env{
+          status: 500,
+          body: "Failure message"
+        }
+
+      # Mock for checkout token failure due to "token": "None"
+      %{method: :post, url: @checkout_token_url, body: @checkout_token_none_failure} ->
+        %Tesla.Env{
+          status: 201,
+          body:
+            Jason.encode!(%{
+              "description" => "Error Message",
+              "token" => "None"
+            })
+        }
+
+      # Mock for checkout token failure due to "description":  "Failure"
+      %{method: :post, url: @checkout_token_url, body: @checkout_description_failure_failure} ->
+        %Tesla.Env{
+          status: 201,
+          body:
+            Jason.encode!(%{
+              "description" => "Failure",
+              "token" => "Potential Error Message"
+            })
         }
 
       %{method: :post} ->
@@ -94,6 +151,30 @@ defmodule AtEx.Gateway.SmsTest do
 
       # assert that message details correspond to details of set up message
       assert msg["text"] == "Hello"
+    end
+
+    test "fetch checkout token successfully" do
+      assert {:ok, token} = Sms.generate_checkout_token(@success_checkout_phonenumber)
+      assert token == @checkout_token
+    end
+
+    test "fetch checkout token failure token: none" do
+      assert {:error, message} =
+               Sms.generate_checkout_token(@checkout_token_none_failure_phonenumber)
+
+      assert message == "Failure - Error Message"
+    end
+
+    test "fetch checkout token failure status code" do
+      assert {:error, message} = Sms.generate_checkout_token(@checkout_status_failure_phonenumber)
+      assert message = "500 - Error Message"
+    end
+
+    test "fetch checkout token failure description: Failure" do
+      assert {:error, message} =
+               Sms.generate_checkout_token(@checkout_description_failure_failure_phonenumber)
+
+      assert message == "Failure - Potential Error Message"
     end
   end
 end


### PR DESCRIPTION
Provides a function AtEx.Gateway.Sms.generate_checkout_token/1 which takes a string containing  a valid phone number and requests a checkout token from the africastalking.com checkout token endpoint.  It determines which URL to use by checking if we are in production or not.  Function returns a success tuple with {:ok, <token>} on success or {:error, <reason>} on failure.  Tests cover all error cases that could be generated.

All tests passed.