### PR TITLE
[WIP]add ability to make a call

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,7 +3,8 @@
 use Mix.Config
 
 config :at_ex,
-  api_key: "6f2a021cbd7b2b0f5e9ba324f42dbf42403ab9a239d1c55c5a68cf54922bda77",
+  # api_key: "6f2a021cbd7b2b0f5e9ba324f42dbf42403ab9a239d1c55c5a68cf54922bda77",
+  api_key: "5e0040e3a07a9b8fa8abf936b1ef834423af7b0f240e07af358e981bf0b0e7a5",
   content_type: "application/x-www-form-urlencoded",
   accept: "application/json",
   auth_token: "",

--- a/lib/at_ex/gateway/voice.ex
+++ b/lib/at_ex/gateway/voice.ex
@@ -1,0 +1,65 @@
+defmodule AtEx.Gateway.Voice do
+  @accept "application/json"
+  @key Application.get_env(:at_ex, :api_key)
+  @content_type "application/x-www-form-urlencoded"
+  # voice endpoints
+  @live_voice_url "https://voice.africastalking.com"
+  @sandbox_voice_url "https://voice.sandbox.africastalking.com"
+
+  # Using this system for delivery of which URL to use (sandbox or live)
+  # determined by whether we are in production or development or test
+  # Selection of the live URL can be forced by setting an environment
+  # variable FORCE_TOKEN_LIVE=YES
+
+  defp get_voice_url() do
+    cond do
+      Mix.env() == :prod -> @live_voice_url
+      System.get_env("FORCE_VOICE_LIVE") == "YES" -> @live_voice_url
+      true -> @sandbox_voice_url
+    end
+  end
+
+  @doc """
+  This function builds and runs a post request to send an SMS via the Africa's talking SMS endpoint, this
+  function accepts a map of parameters that should always contain  the `to` address and the `message` to be
+  sent
+
+  ## Parameters
+    - map: a map containing a `to` and `message` key optionally it may also contain `from`, bulk_sms, enqueue, key_word
+     link_id and retry_hours keys, see the docs at https://build.at-labs.io/docs/sms%2Fsending for how to use these keys
+
+  ## Examples
+      iex> AtEx.Gateway.Voice.make_a_call(%{from: "+254728833181", to: "+254728833000, +254728000000"})
+  """
+
+  @spec make_a_call(map()) :: {:ok, term()} | {:error, term()}
+  def make_a_call(attrs) do
+    call_middleware = [
+      {Tesla.Middleware.BaseUrl, get_voice_url()},
+      Tesla.Middleware.FormUrlencoded,
+      {Tesla.Middleware.Headers,
+       [
+         {"accept", @accept},
+         {"content-type", @content_type},
+         {"apikey", @key}
+       ]}
+    ]
+
+    username = Application.get_env(:at_ex, :username)
+
+    params =
+      attrs
+      |> Map.put(:username, username)
+
+    with {:ok, %Tesla.Env{status: 200} = res} <-
+           Tesla.post(Tesla.client(call_middleware), "/call", params) do
+      {:ok, Jason.decode!(res.body)}
+    else
+      {:ok, val} ->
+        {:error, %{status: val.status, message: val.body}}
+
+      {:error, message} ->
+        {:error, message}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule AtEx.MixProject do
     [
       app: :at_ex,
       version: "0.1.0",
-      elixir: "~> 1.8",
+      elixir: "~> 1.7.3",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule AtEx.MixProject do
     [
       app: :at_ex,
       version: "0.1.0",
-      elixir: "~> 1.7.3",
+      elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,10 @@
 %{
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.2", "1d71150d5293d703a9c38d4329da57d3935faed2031d64bc19e77b654ef2d177", [:mix], [], "hexpm"},
   "tesla": {:hex, :tesla, "1.2.1", "864783cc27f71dd8c8969163704752476cec0f3a51eb3b06393b3971dc9733ff", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
 }

--- a/test/at_ex/gateway/voice_test.exs
+++ b/test/at_ex/gateway/voice_test.exs
@@ -1,0 +1,48 @@
+defmodule AtEx.Gateway.VoiceTest do
+  @moduledoc """
+  This module holds unit tests for the functions in the SMS gateway
+  """
+  use ExUnit.Case
+
+  alias AtEx.Gateway.Voice
+
+  setup do
+    Tesla.Mock.mock(fn
+
+
+      %{method: :post} ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "entries" => [
+                %{
+                  "phoneNumber" => "+254728833181",
+                  "sessionId" => "ATVId_f4eb2e8f8b4c26a30b86a4b4cf6bf7bb",
+                  "status" => "Queued"
+                }
+              ],
+              "errorMessage" => "None"
+            })
+        }
+    end)
+
+    :ok
+  end
+
+  describe "Voice Gateway" do
+    test "make_a_call/1 should queue a call when required parameters are provided" do
+      # make a call details
+      call_details = %{from: "+254728833181", to: "+254780833181"}
+
+      # run details through our code
+      {:ok, result} = Voice.make_a_call(call_details)
+
+      # assert our code gives us a single element list of message
+      [msg] = result["entries"]
+
+      # assert that message details correspond to details of set up message
+      assert msg["status"] == "Queued"
+    end
+  end
+end

--- a/test/at_ex/gateway/voice_test.exs
+++ b/test/at_ex/gateway/voice_test.exs
@@ -8,8 +8,6 @@ defmodule AtEx.Gateway.VoiceTest do
 
   setup do
     Tesla.Mock.mock(fn
-
-
       %{method: :post} ->
         %Tesla.Env{
           status: 200,


### PR DESCRIPTION
Was able to handle errors more gracefully, when the parameter list contains only a single `to` parameter like so `AtEx.Gateway.Voice.make_a_call(%{from: "+254728833181", to: "+254728833000"})`. But there is need to ensure that the endpoint allows for multiple phone numbers like the following `AtEx.Gateway.Voice.make_a_call(%{from: "+254728833181", to: "+254728833000,+254728833001"}). A possible solution may involve using the Enum module to pattern match on the `entries` key in the resulting map where we can either use `reduce`or `reject` to  check for errors or lack of errors.
   As it is if you have a parameter with more than one number it throws the catch all code that is `
`"Failure - Unknown Error"`