### PR TITLE
Feature/starting voice implementation

### DIFF
--- a/lib/at_ex.ex
+++ b/lib/at_ex.ex
@@ -24,36 +24,37 @@ defmodule AtEx do
   alias AtEx.Gateway.{
     Airtime,
     Application,
-    Sms
+    Sms,
+    Voice
   }
 
   @doc """
-  Sends airtime
+    Sends airtime
 
-  ## Parameters
+    ## Parameters
 
-    - map: a map that represents the details of the party you are sending airtime to
+      - map: a map that represents the details of the party you are sending airtime to
 
-  ## Examples
+    ## Examples
 
-  iex> AtEx.send_airtime(%{recipients: [%{phone_number: "+254721978097", amount: "KES 50"}]})
-    {:ok,
-      %{
-        "errorMessage" => "None",
-        "numSent" => 1,
-        "responses" => [
+      iex> AtEx.send_airtime(%{recipients: [%{phone_number: "+254721978097", amount: "KES 50"}]})
+        {:ok,
           %{
-            "amount" => "KES 50.0000",
-            "discount" => "KES 2.0000",
             "errorMessage" => "None",
-            "phoneNumber" => "+254721978097",
-            "requestId" => "ATQid_630557e624c70f2b0d2c5e90ebc282bb",
-            "status" => "Sent"
-          }
-        ],
-          "totalAmount" => "ZAR 7.0277",
-          "totalDiscount" => "ZAR 0.2811"
-      }}
+            "numSent" => 1,
+            "responses" => [
+              %{
+                "amount" => "KES 50.0000",
+                "discount" => "KES 2.0000",
+                "errorMessage" => "None",
+                "phoneNumber" => "+254721978097",
+                "requestId" => "ATQid_630557e624c70f2b0d2c5e90ebc282bb",
+                "status" => "Sent"
+              }
+            ],
+            "totalAmount" => "ZAR 7.0277",
+            "totalDiscount" => "ZAR 0.2811"
+        }}
   """
   defdelegate send_airtime(map), to: Airtime
 
@@ -76,8 +77,8 @@ defmodule AtEx do
   sent
 
   ## Parameters
-  - map: a map containing a `to` and `message` key optionally it may also contain `from`, bulk_sms, enqueue, key_word
-    link_id and retry_hours keys, see the docs at https://build.at-labs.io/docs/sms%2Fsending for how to use these keys
+    - map: a map containing a `to` and `message` key optionally it may also contain `from`, bulk_sms, enqueue, key_word
+      link_id and retry_hours keys, see the docs at https://build.at-labs.io/docs/sms%2Fsending for how to use these keys
 
   ## Examples
   iex> AtEx.send_sms(%{to: "+254721978097", message: "Howdy"})
@@ -121,4 +122,24 @@ defmodule AtEx do
   """
 
   defdelegate fetch_sms(map), to: Sms.Bulk
+
+  @doc """
+  This function makes a POST request to make a call  via the Africa's talking call endpoint, through delegation
+  this function accepts a map of parameters.
+  sent
+
+  ## Parameters
+  attrs: - a map containing:
+  - `from` - your Africa’s Talking phone number (in international format i.e. +XXXYYYYYY)
+  - `to` - A comma separated string of recipients’ phone numbers.
+  - `clientRequestId` - (optional) Variable sent to your Events Callback URL that can be used to tag the call
+
+  ## Example
+      iex> AtEx.call(%{
+      ...>   to: "+254728907896",
+      ...>   from: "+254728900922",
+      ...> })
+      {:ok, result}
+  """
+  defdelegate call(map), to: Voice.MakeCall
 end

--- a/lib/at_ex/gateway/Sms/premium.ex
+++ b/lib/at_ex/gateway/Sms/premium.ex
@@ -119,11 +119,8 @@ defmodule AtEx.Gateway.Sms.PremiumSubscriptions do
   - `lastReceivedId` - (optional) ID of the subscription you believe to be your last. Set it to 0 to for the first time.
 
   ## Example
-  iex> AtEx.Gateway.Sms.create_subscription(%{
-    ...>   shortCode: "1234",
-    ...>   keyword: "keyword",
-    ...> })
-    {:ok, result}
+      iex> AtEx.Gateway.Sms.PremiumSubscriptions.fetch_subscription()
+      {:ok, result}
   """
   @spec fetch_subscriptions() :: {:error, any()} | {:ok, any()}
   def fetch_subscriptions() do
@@ -159,7 +156,7 @@ defmodule AtEx.Gateway.Sms.PremiumSubscriptions do
   - `phoneNumber` - phone number to be unsubscribed
 
   ## Example
-      iex> AtEx.Gateway.Sms.delete_subscription(%{ phoneNumber: "+2541231111"})
+      iex> AtEx.Gateway.Sms.PremiumSubscriptions.delete_subscription(%{ phoneNumber: "+2541231111"})
       {:ok,  %{"description" => "Succeeded", "status" => "Success"}}
   """
   @spec delete_subscription(map()) :: {:error, any()} | {:ok, any()}

--- a/lib/at_ex/gateway/Voice/call_transfer.ex
+++ b/lib/at_ex/gateway/Voice/call_transfer.ex
@@ -1,0 +1,2 @@
+defmodule AtEx.Gateway.Voice.CallTransfer do
+end

--- a/lib/at_ex/gateway/Voice/make_call.ex
+++ b/lib/at_ex/gateway/Voice/make_call.ex
@@ -28,14 +28,8 @@ defmodule AtEx.Gateway.Voice.MakeCall do
       attrs
       |> Map.put(:username, username)
 
-    with {:ok, %{status: 200} = res} <- post("/call", params) do
-      {:ok, Jason.decode!(res.body)}
-    else
-      {:ok, val} ->
-        {:error, %{status: val.status, message: val.body}}
-
-      {:error, message} ->
-        {:error, message}
-    end
+    "/call"
+    |> post(params)
+    |> process_result()
   end
 end

--- a/lib/at_ex/gateway/Voice/make_call.ex
+++ b/lib/at_ex/gateway/Voice/make_call.ex
@@ -1,0 +1,41 @@
+defmodule AtEx.Gateway.Voice.MakeCall do
+  use AtEx.Gateway.Base, url: "https://voice.sandbox.africastalking.com"
+
+  @doc """
+  This function makes a POST request to make a call  via the Africa's talking call endpoint, this
+  function accepts a map of parameters.
+  sent
+
+  ## Parameters
+  attrs: - a map containing:
+  - `from` - your Africa’s Talking phone number (in international format i.e. +XXXYYYYYY)
+  - `to` - A comma separated string of recipients’ phone numbers.
+  - `clientRequestId` - (optional) Variable sent to your Events Callback URL that can be used to tag the call
+
+  ## Example
+      iex> AtEx.Gateway.Voice.MakeCall.call(%{
+      ...>   to: "+254728907896",
+      ...>   from: "+254728900922",
+      ...> })
+      {:ok, result}
+  """
+
+  @spec call(map()) :: {:ok, term()} | {:error, term()}
+  def call(attrs) do
+    username = Application.get_env(:at_ex, :username)
+
+    params =
+      attrs
+      |> Map.put(:username, username)
+
+    with {:ok, %{status: 200} = res} <- post("/call", params) do
+      {:ok, Jason.decode!(res.body)}
+    else
+      {:ok, val} ->
+        {:error, %{status: val.status, message: val.body}}
+
+      {:error, message} ->
+        {:error, message}
+    end
+  end
+end

--- a/lib/at_ex/gateway/Voice/queue_status.ex
+++ b/lib/at_ex/gateway/Voice/queue_status.ex
@@ -1,0 +1,2 @@
+defmodule AtEx.Gateway.Voice.QueueStatus do
+end

--- a/lib/at_ex/gateway/Voice/upload_media.ex
+++ b/lib/at_ex/gateway/Voice/upload_media.ex
@@ -1,0 +1,2 @@
+defmodule AtEx.Gateway.Voice.UploadMedia do
+end

--- a/lib/at_ex/gateway/base_http.ex
+++ b/lib/at_ex/gateway/base_http.ex
@@ -40,9 +40,9 @@ defmodule AtEx.Gateway.Base do
       plug(Tesla.Middleware.FormUrlencoded)
 
       plug(Tesla.Middleware.Headers, [
-        {"accept", @accept},
-        {"content-type", @content_type},
-        {"apikey", @key}
+        {"Accept", @accept},
+        {"Content-Type", @content_type},
+        {"apiKey", @key}
       ])
 
       @doc """

--- a/lib/at_ex/gateway/voice.ex
+++ b/lib/at_ex/gateway/voice.ex
@@ -1,2 +1,0 @@
-defmodule AtEx.Gateway.Voice do
-end

--- a/test/at_ex/gateway/Voice/make_call_test.exs
+++ b/test/at_ex/gateway/Voice/make_call_test.exs
@@ -1,0 +1,58 @@
+defmodule AtEx.Gateway.Voice.MakeCallTest do
+  @moduledoc """
+  This module holds unit tests for the functions in the SMS gateway
+  """
+  use ExUnit.Case, async: true
+
+  import Tesla.Mock
+
+  alias AtEx.Gateway.Voice.MakeCall
+
+  @attr "username="
+
+  setup do
+    mock(fn
+      %{method: :post, body: @attr} ->
+        %Tesla.Env{
+          status: 400,
+          body: "Request is missing required form field 'from'"
+        }
+
+      %{method: :post} ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "entries" => [
+                %{
+                  "phoneNumber" => "+254728907896",
+                  "sessionId" => "ATVId_cb29c2b9fc27983827afc00786c4f9ea",
+                  "status" => "Queued"
+                }
+              ],
+              "errorMessage" => "None"
+            })
+        }
+    end)
+
+    :ok
+  end
+
+  describe "Voice Gateway" do
+    test "call/1 should queue a call with required parameters" do
+      call_details = %{from: "+254728833180", to: "+254728907896"}
+      {:ok, result} = MakeCall.call(call_details)
+
+      [msg] = result["entries"]
+      assert msg["phoneNumber"] == call_details.to
+      assert msg["status"] == "Queued"
+    end
+
+    test "call/1 should error out without from parameter" do
+      {:error, result} = MakeCall.call(%{})
+      "Request is missing required form field 'from'" = result.message
+
+      400 = result.status
+    end
+  end
+end


### PR DESCRIPTION
Thanks to @manuelgeek been able to do mocks for failing tests.
To test this, run `iex -S mix` then at the IEX run `AtEx.Gateway.Voice.MakeCall.call(%{
  to: "+254728907896", from: "+254728900922",
})` here replace the `from` number with one registered in the api key.