### PR TITLE
Env fix for sandbox and prod APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,22 +48,21 @@ end
 - Go to [Africas Talking](https://account.africastalking.com/auth/register) to register for an account.
 - On signing up go to the `https://account.africastalking.com/apps/sandbox` to get an **api key**
 - Add the **api key** in the `api_key:`value in the `config/dev.exs` created above.
+- For sandbox, set the `sandbox` key to `true`
 
 ## Example Configuration setup
 ``` elixir
 config :at_ex,
   api_key: "===INSERT AFRICAS_TALKING_API_KEY HERE ===",
-  content_type: "application/x-www-form-urlencoded",
-  accept: "application/json",
-  username: "sandbox", #change to live username for prod.ex
-  stk_product_name: "AtEx", #Add your specific product name.
+  # When changed to "false" one will use the live endpoint url
+  sandbox: true,
+  username: "sandbox",
+  stk_product_name: "AtEx",
   b2c_product_name: "AtEx",
   b2b_product_name: "AtEx",
   bank_checkout_product_name: "AtEx",
   bank_transfer_product_name: "AtEx",
-  card_checkout_product_name: "AtEx",
-  # When changed to "YES" one will use the live endpoint url when in development
-  force_live_url: "NO"
+  card_checkout_product_name: "AtEx"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Available in Hex, the package can be installed by adding `at_ex` to your list of
 ```elixir
 def deps do
   [
-    {:at_ex, "~> 0.20.21"}
+    {:at_ex, "~> 0.20.22"}
   ]
 end
 ```

--- a/config/dev.sample.exs
+++ b/config/dev.sample.exs
@@ -4,14 +4,12 @@ use Mix.Config
 
 config :at_ex,
   api_key: "===INSERT AFRICAS_TALKING_API_KEY HERE ===",
-  content_type: "application/x-www-form-urlencoded",
-  accept: "application/json",
+  # When changed to "false" one will use the live endpoint url
+  sandbox: true,
   username: "sandbox",
   stk_product_name: "AtEx",
   b2c_product_name: "AtEx",
   b2b_product_name: "AtEx",
   bank_checkout_product_name: "AtEx",
   bank_transfer_product_name: "AtEx",
-  card_checkout_product_name: "AtEx",
-  # When changed to "YES" one will use the live endpoint url
-  force_live_url: "NO"
+  card_checkout_product_name: "AtEx"

--- a/lib/at_ex/util.ex
+++ b/lib/at_ex/util.ex
@@ -5,8 +5,8 @@ defmodule AtEx.Util do
   @spec get_url(String.t(), String.t()) :: String.t()
   def get_url(live_url, sandbox_url) do
     cond do
-      Mix.env() == :prod -> live_url
-      Application.get_env(:at_ex, :force_live_url) == "YES" -> live_url
+      Application.get_env(:at_ex, :sandbox) === false -> live_url
+      Application.get_env(:at_ex, :sandbox) === true -> sandbox_url
       true -> sandbox_url
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AtEx.MixProject do
   def project do
     [
       app: :at_ex,
-      version: "0.20.21",
+      version: "0.20.22",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
**Cause**
The wrapper checks for `Mix.env()` to determine the API to hit, either `sandbox` or `production`. However, all dependencies are compiled as `:prod` hence the wrapper all hit the `:prod` endpoint.

**Solution**
Removed the `force-live`url` kwy and added `sandbox` key to the `at_ex` configs. The key is a boolean to determine whether the keys added are for sandbox or live.

Re read on the README configs to understand better