### PR TITLE
Introduce elixir 1.20.2

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,25 +10,32 @@ on:
 jobs:
   mix_test:
     name: mix test (Elixir ${{ matrix.elixir }} | OTP ${{ matrix.otp }})
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - elixir: 1.8.x
             otp: 21
+            os: ubuntu-20.04
           - elixir: 1.9.x
             otp: 22
+            os: ubuntu-20.04
           - elixir: 1.11.x
             otp: 23
+            os: ubuntu-20.04
           - elixir: 1.12.x
             otp: 24
+            os: ubuntu-20.04
           - elixir: 1.18.x
             otp: 27
+            os: ubuntu-24.04
           - elixir: 1.19.x
             otp: 28
+            os: ubuntu-24.04
           - elixir: 1.20.x
             otp: 29
+            os: ubuntu-24.04
     env:
       MIX_ENV: test
     steps:
@@ -43,7 +50,7 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ matrix.otp }}-${{ matrix.elixir }}-build
+          key: ${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-build
       - run: mix deps.get --only test
       - run: mix lint
       - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,32 +10,17 @@ on:
 jobs:
   mix_test:
     name: mix test (Elixir ${{ matrix.elixir }} | OTP ${{ matrix.otp }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.8.x
-            otp: 21
-            os: ubuntu-20.04
-          - elixir: 1.9.x
-            otp: 22
-            os: ubuntu-20.04
-          - elixir: 1.11.x
-            otp: 23
-            os: ubuntu-20.04
-          - elixir: 1.12.x
-            otp: 24
-            os: ubuntu-20.04
           - elixir: 1.18.x
             otp: 27
-            os: ubuntu-24.04
           - elixir: 1.19.x
             otp: 28
-            os: ubuntu-24.04
           - elixir: 1.20.x
             otp: 29
-            os: ubuntu-24.04
     env:
       MIX_ENV: test
     steps:
@@ -50,7 +35,7 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-build
+          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-build
       - run: mix deps.get --only test
       - run: mix lint
       - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -39,5 +39,5 @@ jobs:
             _build
           key: ${{ matrix.otp }}-${{ matrix.elixir }}-build
       - run: mix deps.get --only test
-      # - run: mix lint
+      - run: mix lint
       - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,6 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - elixir: 1.12.x
+            otp: 24
           - elixir: 1.18.x
             otp: 27
           - elixir: 1.19.x

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,6 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - elixir: 1.8.x
+            otp: 21
+          - elixir: 1.9.x
+            otp: 22
+          - elixir: 1.11.x
+            otp: 23
           - elixir: 1.12.x
             otp: 24
           - elixir: 1.18.x

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,8 @@
 # use Mix.Config
 import Config
 
+config :tesla, disable_deprecated_builder_warning: true
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/lib/at_ex/gateway/Payments/Bank/checkout.ex
+++ b/lib/at_ex/gateway/Payments/Bank/checkout.ex
@@ -68,17 +68,16 @@ defmodule AtEx.Gateway.Payments.Bank.Checkout do
       !Map.has_key?(attrs, :bankAccount) || !is_map(attrs.bankAccount) ->
         {:error, "The required member 'bankAccount' must be a map"}
 
-      is_map(attrs.bankAccount) && !Map.has_key?(attrs.bankAccount, :accountName) ->
+      !Map.has_key?(attrs.bankAccount, :accountName) ->
         {:error, "The 'bankAccount' map is missing required member 'accountName'"}
 
-      is_map(attrs.bankAccount) && !Map.has_key?(attrs.bankAccount, :accountNumber) ->
+      !Map.has_key?(attrs.bankAccount, :accountNumber) ->
         {:error, "The 'bankAccount' map is missing required member 'accountNumber'"}
 
-      is_map(attrs.bankAccount) and !Map.has_key?(attrs.bankAccount, :bankCode) ->
+      !Map.has_key?(attrs.bankAccount, :bankCode) ->
         {:error, "The 'bankAccount' map is missing required member 'bankCode'"}
 
-      is_map(attrs.bankAccount) and attrs.bankAccount.bankCode === 234_002 and
-          !Map.has_key?(attrs.bankAccount, :dateOfBirth) ->
+      attrs.bankAccount.bankCode === 234_002 and !Map.has_key?(attrs.bankAccount, :dateOfBirth) ->
         {:error,
          "The 'bankAccount' map is missing optional member 'dateOfBirth' required for this bank"}
 

--- a/lib/at_ex/gateway/Payments/Bank/transfer.ex
+++ b/lib/at_ex/gateway/Payments/Bank/transfer.ex
@@ -78,17 +78,17 @@ defmodule AtEx.Gateway.Payments.Bank.Transfer do
             !Map.has_key?(param, :bankAccount) || !is_map(param.bankAccount) ->
               {:error, "The required member 'bankAccount' must be a map"}
 
-            is_map(param.bankAccount) && !Map.has_key?(param.bankAccount, :accountName) ->
+            !Map.has_key?(param.bankAccount, :accountName) ->
               {:error, "The 'bankAccount' map is missing required member 'accountName'"}
 
-            is_map(param.bankAccount) && !Map.has_key?(param.bankAccount, :accountNumber) ->
+            !Map.has_key?(param.bankAccount, :accountNumber) ->
               {:error, "The 'bankAccount' map is missing required member 'accountNumber'"}
 
-            is_map(param.bankAccount) and !Map.has_key?(param.bankAccount, :bankCode) ->
+            !Map.has_key?(param.bankAccount, :bankCode) ->
               {:error, "The 'bankAccount' map is missing required member 'bankCode'"}
 
-            is_map(param.bankAccount) and param.bankAccount.bankCode === 234_002 and
-                !Map.has_key?(attrs.bankAccount, :dateOfBirth) ->
+            param.bankAccount.bankCode === 234_002 and
+                !Map.has_key?(param.bankAccount, :dateOfBirth) ->
               {:error,
                "The 'bankAccount' map is missing optional member 'dateOfBirth' required for this bank"}
 

--- a/lib/at_ex/gateway/base_http.ex
+++ b/lib/at_ex/gateway/base_http.ex
@@ -34,7 +34,6 @@ defmodule AtEx.Gateway.Base do
 
       @accept "application/json"
       @content_type "application/x-www-form-urlencoded"
-      @key Application.fetch_env(:at_ex, :api_key)
 
       plug(Tesla.Middleware.BaseUrl, @config[:url])
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule AtEx.MixProject do
     [
       app: :at_ex,
       version: "0.20.23",
-      elixir: "~> 1.12",
+      elixir: "~> 1.20.2",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule AtEx.MixProject do
     [
       app: :at_ex,
       version: "0.20.23",
-      elixir: "~> 1.20",
+      elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule AtEx.MixProject do
     [
       app: :at_ex,
       version: "0.20.23",
-      elixir: "~> 1.18",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule AtEx.MixProject do
     [
       app: :at_ex,
       version: "0.20.23",
-      elixir: "~> 1.20.2",
+      elixir: "~> 1.20",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule AtEx.MixProject do
     [
       app: :at_ex,
       version: "0.20.23",
-      elixir: "~> 1.8",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),


### PR DESCRIPTION
## What is the Purpose?


Briefly describe what the PR addresses
Bump the latest Elixir version 
Introduce linting CI 

## What was the approach?

Briefly describe the approach used to address the issue

Linting warnings have been fixed
It bumped the Elixir version to 1.20.3
It silence telsa warning for now, which will be fixed in a later PR

## Are there any concerns to addressed further before or after merging this PR?

State some additional info if any. For instance running `mix deps.get` or setting some environment variable(s)
None
## Mentions?

Mention persons you'd like to review this PR
@TraceyOnim  @GettyOrawo  @GraceKiarie @75pollet 
## Issue(s) affected?

List of issues addressed by this PR.

- elixir version
- linting fixes